### PR TITLE
Fixes PDF disappearing when app backgrounded. Fixes #9.

### DIFF
--- a/src/AndroidPdfViewer.d.ts
+++ b/src/AndroidPdfViewer.d.ts
@@ -5,6 +5,8 @@ declare module com.github.barteksc.pdfviewer {
     fromFile(file: java.io.File): Configurator;
     fromUri(uri: android.net.Uri): Configurator;
     public constructor(param0: globalAndroid.content.Context, param1: globalAndroid.util.AttributeSet);
+    public onAttachedToWindow(): void;
+    public isRecycled(): boolean;
   }
 
   export module listener {

--- a/src/pdf-view.android.d.ts
+++ b/src/pdf-view.android.d.ts
@@ -1,13 +1,22 @@
 /// <reference types="androidpdfviewer" />
 import pdfviewer = com.github.barteksc.pdfviewer;
 import { PDFViewCommon } from './pdf-view.common';
+declare class PDFViewSubclass extends pdfviewer.PDFView {
+    static constructorCalled: boolean;
+    private uri;
+    constructor(a: any, b: any);
+    setUri(uri: globalAndroid.net.Uri): void;
+    drawPdf(): void;
+    onAttachedToWindow(): void;
+}
 export declare class PDFView extends PDFViewCommon {
     private promise;
     private tempFolder;
     private onLoadHandler;
-    get android(): pdfviewer.PDFView;
-    set android(value: pdfviewer.PDFView);
-    createNativeView(): pdfviewer.PDFView;
+    get android(): PDFViewSubclass;
+    set android(value: PDFViewSubclass);
+    createNativeView(): PDFViewSubclass;
     loadPDF(src: string): void;
     private cacheThenLoad;
 }
+export {};

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,3 +1,12 @@
 dependencies {
-    implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
+    implementation 'com.github.TalbotGooday:AndroidPdfViewer:3.1.0-beta.3'
+}
+repositories {
+    maven {
+        url 'https://jitpack.io'
+        content {
+            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at jcenter.
+            includeGroup "com.github.TalbotGooday"
+        }
+    }
 }


### PR DESCRIPTION
I believe this fixes #9.

The implementation is based off of https://github.com/wonday/react-native-pdf's implementation. The changes include:

1. Updating the Java dependency to https://github.com/TalbotGooday/AndroidPdfViewer. This is the implementation that both [`react-native-pdf`](https://github.com/wonday/react-native-pdf/blob/master/android/build.gradle#L62-L65) and even [`madmas/nativescript-pdf-view`](https://github.com/madmas/nativescript-pdf-view/blob/master/src/platforms/android/include.gradle) are using. It claims to be maintained, unlike the original `barteksc` repository.
2. I subclassed `pdfviewer.PDFView` to enable overriding the `onAttachedToWindow` method. (The rationale for that will be discussed in the next point.) I ended up adding several properties as well, to enable the `drawPdf` method.
3. I added `drawPdf`, moving the code responsible for loading and displaying the PDF from the NativeScript `PDFView` class to the new subclass. _This was done to allow `onAttachedToWindow` to re-draw the entire PDF when called_, as is done in [`react-native-pdf`'s version](https://github.com/wonday/react-native-pdf/blob/master/android/src/main/java/org/wonday/pdf/PdfView.java#L206-L211).

I, unfortunately, don't have a complete understanding as to why the bug happens and why this fixes it — this PR is far more of a "copy a working implementation" kind of fix than a "understand and fix the problem" kind of fix.

Happy to adjust the PR as necessary!